### PR TITLE
Support IO#wait and timeouts

### DIFF
--- a/ext/libev_scheduler/scheduler.c
+++ b/ext/libev_scheduler/scheduler.c
@@ -219,10 +219,13 @@ VALUE Scheduler_io_wait(VALUE self, VALUE io, VALUE events, VALUE timeout) {
   rb_fiber_yield(1, &nil);
   scheduler->pending_count--;
   ev_io_stop(scheduler->ev_loop, &io_watcher.io);
-  if (use_timeout)
+  if (use_timeout) {
     ev_timer_stop(scheduler->ev_loop, &timeout_watcher.timer);
-  
-  return self;
+    if (ev_timer_remaining(scheduler->ev_loop, &timeout_watcher.timer) <= 0)
+      return nil;
+  }
+
+  return events;
 }
 
 struct libev_child {


### PR DESCRIPTION
The [`#io_wait`](https://ruby-doc.org/core-3.0.0/Fiber/SchedulerInterface.html#method-i-io_wait) implementation expects to return the subset of events that are ready immediately, not a `Scheduler` object.

Without this PR the added timeout test (and the existing test with added `wait_readable` / `wait_writable` assertions) fail with `TypeError: no implicit conversion of Libev::Scheduler into Integer`.