### PR TITLE
Support Fiber#raise

### DIFF
--- a/ext/libev_scheduler/scheduler.c
+++ b/ext/libev_scheduler/scheduler.c
@@ -219,10 +219,13 @@ VALUE Scheduler_io_wait(VALUE self, VALUE io, VALUE events, VALUE timeout) {
   rb_fiber_yield(1, &nil);
   scheduler->pending_count--;
   ev_io_stop(scheduler->ev_loop, &io_watcher.io);
-  if (use_timeout)
+  if (use_timeout) {
     ev_timer_stop(scheduler->ev_loop, &timeout_watcher.timer);
-  
-  return self;
+    if (ev_timer_remaining(scheduler->ev_loop, &timeout_watcher.timer) <= 0)
+      return nil;
+  }
+
+  return events;
 }
 
 struct libev_child {

--- a/test/test_mutex.rb
+++ b/test/test_mutex.rb
@@ -73,7 +73,6 @@ class TestFiberMutex < MiniTest::Test
   end
 
   def test_mutex_fiber_raise
-    skip "stuck"
     mutex = Mutex.new
     ran = false
 
@@ -87,7 +86,7 @@ class TestFiberMutex < MiniTest::Test
         Fiber.set_scheduler scheduler
 
         f = Fiber.schedule do
-          assert_raise_message("bye") do
+          assert_raises(RuntimeError) do
             p [2, :pre_lock]
             mutex.lock
             p [2, :post_lock]

--- a/test/test_sleep.rb
+++ b/test/test_sleep.rb
@@ -49,4 +49,21 @@ class TestFiberSleep < MiniTest::Test
     assert_operator seconds, :>=, 1.0, "actual: %p" % seconds
     assert_operator elapsed, :>=, 1.0, "actual: %p" % elapsed
   end
+
+  def test_raise_exits_sleep
+    finished = false
+    thread = Thread.new do
+      scheduler = Libev::Scheduler.new
+      Fiber.set_scheduler scheduler
+      f = Fiber.schedule do
+        sleep
+      rescue
+        finished = true
+      end
+      Fiber.schedule {f.raise}
+    end
+
+    thread.join
+    assert finished
+  end
 end


### PR DESCRIPTION
Add support for Fiber#raise by rescuing exceptions during the calls to `rb_fiber_yield`. This allows the two added tests (and one un-skipped test) to pass without hanging.

The code change to `Scheduler_io_wait` conflicts with the fix in #1 so I've left that commit in this PR as well.